### PR TITLE
Add pagination support, run on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Github Release Tracking Plugin
 
-Integrate PostHog with GitHub and get automatic graph annotations based on your repository's tags so you can analyze the impact of new releases on your key metrics. 
+Integrate PostHog with GitHub and get automatic graph annotations based on your repository's tags so you can analyze the impact of new releases on your key metrics.
 
 ![Plugin Screenshot](readme-assets/release-tracker.png)
 


### PR DESCRIPTION
Closes #2 

## Changes

- `runEveryDay` will also run at `setupPlugin`
- Add mechanism to prevent a run if one has happened in the last hour
- Support pagination on the annotations endpoint, preventing duplicates