### PR TITLE
fix(auth): update deprecated current user posthog endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ async function setupPlugin({ config, global }) {
         : {}
 
     try {
-        const posthogRes = await fetchWithRetry(`${global.posthogHost}/api/user`, global.posthogOptions)
+        const posthogRes = await fetchWithRetry(`${global.posthogHost}/api/users/@me`, global.posthogOptions)
 
         const githubRes = await fetchWithRetry(
             `https://api.github.com/repos/${config.ghOwner}/${config.ghRepo}`,


### PR DESCRIPTION
Hey there!

When trying to enable this plugin in PostHog we were receiving the `Invalid PostHog Personal API key or GitHub Personal Token` error, which is thrown by the `setupPlugin` method

From having a fiddle with this repository and manually trying the requests in the `setupPlugin` method I received a 404 response from the `posthogRes` fetch

```
{
  "type": "invalid_request",
  "code": "not_found",
  "detail": "Endpoint not found.",
  "attr": null
}
```

I had a look at the PostHog documentation and noticed that the `/api/user` endpoint being used was [deprecated in April 2021](https://posthog.com/docs/api/user#user---deprecated) in favour of the `/api/users/@me` [endpoint](https://posthog.com/docs/api/user#list-current-user)

I manually requested to the `/api/users/@me` endpoint to verify that it worked with the options used in the original request and it seems to be correct, and figured I'd open a PR

Let me know if there's any feedback / issues :)