### PR TITLE
add message when failing to create tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,6 +102,9 @@ async function runEveryMinute({ config, global, cache }) {
 
         if (createAnnotationRes.status === 201) {
             posthog.capture('created_tag_annotation', { tag: tag.name })
+        } else {
+            const errorMessage = await createAnnotationRes.json()
+            console.error('failed to create tag', tag.name, ' with status ', createAnnotationRes.status, ' and error ', errorMessage)
         }
     }
     await cache.set('lastRun', new Date().getTime())


### PR DESCRIPTION
when the plugin setup succeeds but tag creation fails there is no debug output

I am answering this question in the community slack https://posthogusers.slack.com/archives/C01GLBKHKQT/p1652201730616449 about what permissions are needed for the plugin. Without errors it is hard to discover the necessary permissions