### PR TITLE
feat: Throw retry errors on unknown failures in setup

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+import { RetryError } from '@posthog/plugin-scaffold'
+
 class KnownError extends Error {}
 
 async function setupPlugin({ config, global }) {
@@ -39,7 +41,7 @@ async function setupPlugin({ config, global }) {
         if (e instanceof KnownError) {
             throw(e)
         }
-        throw new Error('Unknown error when trying to connect to GitHub and PostHog.')
+        throw new RetryError('Unknown error when trying to connect to GitHub and PostHog.')
     }
 }
 


### PR DESCRIPTION
After the latest changes we currently do no retries and the app gets disabled because of connection errors etc.

See user problem https://posthogusers.slack.com/archives/C01GLBKHKQT/p1656705203411649